### PR TITLE
Skip features with no geometry

### DIFF
--- a/qgis_utils.py
+++ b/qgis_utils.py
@@ -113,8 +113,10 @@ def generate_decision_map(layer_in, aa, out, out_encoding):
 
     for feat in layer_in.getFeatures():
         inGeom = feat.geometry()
+        inGeom = QgsGeometry()
         id = str(feat.id())
-        outFeat.setGeometry(inGeom)
+        if inGeom is not None:
+            outFeat.setGeometry(inGeom)
         outFeat.setAttribute(0, aa[id].category_id)
         writer.addFeature(outFeat)
 


### PR DESCRIPTION
This is a very minor bugfix  in QGIS2 version where the plugin crashes with no useful error message when fed with an input file containing NULL geometries.
Explanations below.

Currently the plugin crashes if a geometry is loaded with features with "null" geometry.
QGIS2 cannot execute the method QgsFeature.setGeometry(None)
by skipping the call of setGeometry(), the output file keeps the same null geometries as the input file.

QGIS3 can handle null geometries better and this is no problem ( QgsFeature.setGeometry(None) works and results in a QgsGeometry of type Unknown )